### PR TITLE
fix: use approvals instead of approval

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ type Domain = {
 The returned `VisualizationResult` will contain some important fields like:
 - `assetsIn`, an array of of assets that user should receive.
 - `assetsOut`, an array of the assets that are leaving user wallet.
-- `approval`, an array of assets that user is granting an `operator` approval for.
+- `approvals`, an array of assets that user is granting an `operator` approvals for.
 - `liviness`, an optional object that highlight from and till which timestamp the above information is considered valid by the protocol
 
 # Features

--- a/src/simulator/index.ts
+++ b/src/simulator/index.ts
@@ -69,7 +69,7 @@ export default class Simulator {
    * @see https://docs.soliditylang.org/en/v0.8.13/abi-spec.html
    * @param {DebugCallTracerWithLogs} data data to be processed recursively
    * @param {Transfer[]} transfersReference mutable array to append transfer records
-   * @param {Approval[]} approvalsReference mutable array to append approval records
+   * @param {Approval[]} approvalsReference mutable array to append approvals records
    */
   private processTraceCallData = (
     data: DebugCallTracerWithLogs,

--- a/src/types/visualizer.ts
+++ b/src/types/visualizer.ts
@@ -25,7 +25,7 @@ export type VisualizationResult = {
   liveness?: Liveness;
   assetsIn: AssetInOut[];
   assetsOut: AssetInOut[];
-  approval: Approval[];
+  approvals: Approval[];
 };
 
 export type EIP712Protocol<T> = {

--- a/src/visualizer/blur-io/index.ts
+++ b/src/visualizer/blur-io/index.ts
@@ -79,7 +79,7 @@ export const visualize = (message: BlurIoOrder, domain: Domain): VisualizationRe
       from: Number(message.listingTime) * 1000,
       to: Number(message.expirationTime) * 1000,
     },
-    approval: [],
+    approvals: [],
   };
 };
 

--- a/src/visualizer/erc20-permit/index.ts
+++ b/src/visualizer/erc20-permit/index.ts
@@ -16,7 +16,7 @@ export const visualize = (
     protocol: PROTOCOL_ID.ERC20_PERMIT,
     assetsIn: [],
     assetsOut: [],
-    approval: [
+    approvals: [
       {
         address: domain.verifyingContract,
         type: ASSET_TYPE.ERC20,

--- a/src/visualizer/looksrare/index.ts
+++ b/src/visualizer/looksrare/index.ts
@@ -77,7 +77,7 @@ export const visualize = (
       from: Number(message.startTime) * 1000,
       to: Number(message.endTime) * 1000,
     },
-    approval: [],
+    approvals: [],
   };
 };
 

--- a/src/visualizer/seaport/index.ts
+++ b/src/visualizer/seaport/index.ts
@@ -130,7 +130,7 @@ export const visualize = (
     },
     assetsIn,
     assetsOut,
-    approval: [],
+    approvals: [],
   };
 };
 

--- a/test/visualizer/blur-io/index.test.ts
+++ b/test/visualizer/blur-io/index.test.ts
@@ -42,7 +42,7 @@ describe("blur.io", () => {
           amounts: ["1"],
         },
       ],
-      approval: [],
+      approvals: [],
       liveness: { from: 1677736151000, to: 1678340951000 },
     });
   });
@@ -67,7 +67,7 @@ describe("blur.io", () => {
           amounts: ["800000000000000000"],
         },
       ],
-      approval: [],
+      approvals: [],
       liveness: { from: 1677736151000, to: 1678340951000 },
     });
   });
@@ -91,7 +91,7 @@ describe("blur.io", () => {
           amounts: ["10000000000000000"],
         },
       ],
-      approval: [],
+      approvals: [],
       liveness: { from: 1678461048000, to: 1709997048000 },
     });
   });
@@ -119,7 +119,7 @@ describe("blur.io", () => {
           amounts: ["800000000000000000"],
         },
       ],
-      approval: [],
+      approvals: [],
       liveness: { from: 1677736151000, to: 1678340951000 },
     });
   });

--- a/test/visualizer/erc20-permit/index.test.ts
+++ b/test/visualizer/erc20-permit/index.test.ts
@@ -34,7 +34,7 @@ describe("ERC20 Permit", () => {
     }).toThrowError("wrong ERC20 Permit message schema");
   });
 
-  it("should successfully visualize DAI approval", async () => {
+  it("should successfully visualize DAI approvals", async () => {
     const result = await visualize<PermitMessage>(
       erc20DaiPermitMessage,
       erc20PermitDomain
@@ -44,7 +44,7 @@ describe("ERC20 Permit", () => {
       protocol: "ERC20_PERMIT",
       assetsIn: [],
       assetsOut: [],
-      approval: [
+      approvals: [
         {
           address: "0x6B175474E89094C44Da98b954EedeAC495271d0F",
           type: "ERC20",
@@ -59,7 +59,7 @@ describe("ERC20 Permit", () => {
     });
   });
 
-  it("should successfully visualize DAI approval with zero amount", async () => {
+  it("should successfully visualize DAI approvals with zero amount", async () => {
     const result = await visualize<PermitMessage>(
       { ...erc20DaiPermitMessage, allowed: false, nonce: "2" },
       erc20PermitDomain
@@ -69,7 +69,7 @@ describe("ERC20 Permit", () => {
       protocol: "ERC20_PERMIT",
       assetsIn: [],
       assetsOut: [],
-      approval: [
+      approvals: [
         {
           address: "0x6B175474E89094C44Da98b954EedeAC495271d0F",
           type: "ERC20",
@@ -82,14 +82,14 @@ describe("ERC20 Permit", () => {
     });
   });
 
-  it("should successfully visualize ERC2612 approval", async () => {
+  it("should successfully visualize ERC2612 approvals", async () => {
     const result = await visualize<PermitMessage>(ERC2612Message, erc20PermitDomain);
 
     expect(result).toEqual({
       protocol: "ERC20_PERMIT",
       assetsIn: [],
       assetsOut: [],
-      approval: [
+      approvals: [
         {
           address: "0x6B175474E89094C44Da98b954EedeAC495271d0F",
           type: "ERC20",

--- a/test/visualizer/looksrare/index.test.ts
+++ b/test/visualizer/looksrare/index.test.ts
@@ -60,7 +60,7 @@ describe("looksrare", () => {
           amounts: ["1"],
         },
       ],
-      approval: [],
+      approvals: [],
       liveness: { from: 1677588653000, to: 1680266940000 },
     });
   });
@@ -87,7 +87,7 @@ describe("looksrare", () => {
           amounts: ["1000000000000000"],
         },
       ],
-      approval: [],
+      approvals: [],
       liveness: { from: 1677588943000, to: 1677675336000 },
     });
   });
@@ -115,7 +115,7 @@ describe("looksrare", () => {
           amounts: ["1000000000000000"],
         },
       ],
-      approval: [],
+      approvals: [],
       liveness: { from: 1677588943000, to: 1677675336000 },
     });
   });
@@ -147,7 +147,7 @@ describe("looksrare", () => {
           amounts: ["1"],
         },
       ],
-      approval: [],
+      approvals: [],
       liveness: { from: 1677588653000, to: 1680266940000 },
     });
   });

--- a/test/visualizer/seaport/index.test.ts
+++ b/test/visualizer/seaport/index.test.ts
@@ -68,7 +68,7 @@ describe("visualizer", () => {
             amounts: ["50", "100"],
           },
         ],
-        approval: [],
+        approvals: [],
       });
     });
 
@@ -96,7 +96,7 @@ describe("visualizer", () => {
             amounts: ["50", "100"],
           },
         ],
-        approval: [],
+        approvals: [],
       });
     });
 
@@ -126,7 +126,7 @@ describe("visualizer", () => {
             amounts: ["1"],
           },
         ],
-        approval: [],
+        approvals: [],
       });
     });
 
@@ -156,7 +156,7 @@ describe("visualizer", () => {
             amounts: ["50", "100"],
           },
         ],
-        approval: [],
+        approvals: [],
       });
     });
 
@@ -181,7 +181,7 @@ describe("visualizer", () => {
             amounts: ["4000000000000000"],
           },
         ],
-        approval: [],
+        approvals: [],
       });
     });
 
@@ -212,7 +212,7 @@ describe("visualizer", () => {
             amounts: ["100000000000000000"],
           },
         ],
-        approval: [],
+        approvals: [],
       });
     });
 
@@ -242,7 +242,7 @@ describe("visualizer", () => {
           from: 1677592745000,
           to: 1678197528000,
         },
-        approval: [],
+        approvals: [],
       });
     });
 
@@ -276,7 +276,7 @@ describe("visualizer", () => {
           from: 1677130860000,
           to: 1677303660000,
         },
-        approval: [],
+        approvals: [],
       });
     });
 
@@ -304,7 +304,7 @@ describe("visualizer", () => {
           from: 1677130860000,
           to: 1677303660000,
         },
-        approval: [],
+        approvals: [],
       });
     });
 
@@ -332,7 +332,7 @@ describe("visualizer", () => {
           from: 1677130860000,
           to: 1677303660000,
         },
-        approval: [],
+        approvals: [],
       });
     });
 
@@ -360,7 +360,7 @@ describe("visualizer", () => {
           from: 1680010140000,
           to: 1680269340000,
         },
-        approval: [],
+        approvals: [],
       });
     });
   });


### PR DESCRIPTION
to keep naming consistent i changed `approval` to `approvals`
