### PR TITLE
feat: add custom errors

### DIFF
--- a/src/simulator/index.ts
+++ b/src/simulator/index.ts
@@ -14,6 +14,7 @@ import {
   ERC20_ERC721_TRANSFER_TOPIC,
   ERC721_ERC1155_APPROVE_ALL_TOPIC,
   TRUE,
+  WizardError,
   ZERO_ADDRESS,
   abiCoder,
   addressFrom32bytesTo20bytes,
@@ -34,18 +35,18 @@ export default class Simulator {
   }
 
   async simulate(params: SimulationParams): Promise<AssetsTransfersAndApprovalsRes> {
-    if (!params.chainId) throw new Error("undefined chainId param");
+    if (!params.chainId) throw new WizardError("undefined chainId param");
 
-    if (!params.from) throw new Error("undefined from param");
+    if (!params.from) throw new WizardError("undefined from param");
 
-    if (!params.to) throw new Error("undefined to param");
+    if (!params.to) throw new WizardError("undefined to param");
 
-    if (!params.calldata) throw new Error("undefined to calldata");
+    if (!params.calldata) throw new WizardError("undefined calldata param");
 
     const debugTraceCall = this.providers[params.chainId];
 
     if (!debugTraceCall) {
-      throw new Error(`Simulator: no debugProvider found for chainId: ${params.chainId}`);
+      throw new WizardError(`unsupported chain_id: ${params.chainId}`);
     }
 
     const trace = await debugTraceCall(params);
@@ -78,7 +79,7 @@ export default class Simulator {
   ) => {
     data?.forEach((call) => {
       if (call.error) {
-        throw new Error(
+        throw new WizardError(
           `Transaction will fail with error: '${decodeErrorMessage(call.output)}'`
         );
       }

--- a/src/simulator/providers/nodeReal.ts
+++ b/src/simulator/providers/nodeReal.ts
@@ -1,5 +1,6 @@
 import { DebugCallTracerWithLogs, DebugProvider } from "../../types/simulator";
 import axios from "axios";
+import { WizardError } from "../../utils";
 
 type CallTracerParams = {
   from: string;
@@ -83,7 +84,7 @@ async function callTracer(
   if (!res.data.result) {
     const errorCode = res.data?.error?.code;
     const message = res.data?.error?.message;
-    throw new Error(
+    throw new WizardError(
       `NodeReal: simulation failed with code error: ${errorCode} and message: ${message}`
     );
   }

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -66,3 +66,14 @@ export const getPaymentAssetType = (tokenAddress: string): ASSET_TYPE => {
 
   return isNative ? ASSET_TYPE.NATIVE : ASSET_TYPE.ERC20;
 };
+
+/**
+ * @param {string} message error message
+ * @throws WizardError
+ */
+export class WizardError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "WizardError";
+  }
+}

--- a/src/visualizer/blur-io/index.ts
+++ b/src/visualizer/blur-io/index.ts
@@ -2,7 +2,12 @@ import { PROTOCOL_ID } from "..";
 import { ASSET_TYPE, AssetInOut } from "../../types";
 import { BlurIoOrder, BlurIoSide } from "../../types/blur";
 import { Domain, EIP712Protocol, VisualizationResult } from "../../types/visualizer";
-import { ZERO_ADDRESS, getPaymentAssetType, isSameAddress } from "../../utils";
+import {
+  WizardError,
+  ZERO_ADDRESS,
+  getPaymentAssetType,
+  isSameAddress,
+} from "../../utils";
 import {
   BLUR_IO_COLLECTION_BID_POLICY,
   BLUR_IO_INVERSE_BASIS_POINT,
@@ -20,7 +25,7 @@ export const isCorrectDomain = (domain: Domain) => {
 export const visualize = (message: BlurIoOrder, domain: Domain): VisualizationResult => {
   if (!isCorrectDomain(domain)) throw new Error("wrong blur.io domain");
   if (!isValidBlurIoPolicy(message.matchingPolicy))
-    throw new Error("unrecognized blur.io matching policy");
+    throw new WizardError("unrecognized blur.io matching policy");
 
   // Fees and Price calculation
   const price = BigInt(message.price);
@@ -68,7 +73,7 @@ export const visualize = (message: BlurIoOrder, domain: Domain): VisualizationRe
     assetsOut.push(paymentAsset);
     assetsIn.push(nftAsset);
   } else {
-    throw new Error("unrecognized blur.io order side");
+    throw new WizardError("unrecognized blur.io order side");
   }
 
   return {

--- a/src/visualizer/erc20-permit/index.ts
+++ b/src/visualizer/erc20-permit/index.ts
@@ -1,13 +1,13 @@
 import { ASSET_TYPE, PermitMessage } from "../../types";
 import { PROTOCOL_ID } from "..";
-import { MaxUint256 } from "../../utils";
+import { MaxUint256, WizardError } from "../../utils";
 import { Domain, VisualizationResult } from "../../types/visualizer";
 
 export const visualize = (
   message: PermitMessage,
   domain: Domain
 ): VisualizationResult => {
-  if (!isERC20Permit(message)) throw new Error("wrong ERC20 Permit message schema");
+  if (!isERC20Permit(message)) throw new WizardError("wrong ERC20 Permit message schema");
   const amount =
     message.value?.toString() ||
     (message.allowed?.toString() === "true" ? MaxUint256.toString() : "0");

--- a/src/visualizer/index.ts
+++ b/src/visualizer/index.ts
@@ -9,6 +9,7 @@ import erc20Permit from "./erc20-permit";
 import looksrare from "./looksrare";
 import seaport from "./seaport";
 import { Domain, VisualizationResult } from "../types/visualizer";
+import { WizardError } from "../utils";
 
 export enum PROTOCOL_ID {
   OPENSEA_SEAPORT = "OPENSEA_SEAPORT",
@@ -52,6 +53,6 @@ export default async function visualize<T extends object>(
         return erc20Permit.visualize(message as PermitMessage, domain);
       }
 
-      throw new Error("Unrecognized/Unsupported EIP712Protocol Domain");
+      throw new WizardError("Unrecognized/Unsupported EIP712Protocol Domain");
   }
 }

--- a/src/visualizer/looksrare/index.ts
+++ b/src/visualizer/looksrare/index.ts
@@ -6,7 +6,7 @@ import { PROTOCOL_ID } from "..";
 import { ASSET_TYPE, AssetInOut } from "../../types";
 import { LooksrareMakerOrderWithEncodedParams, STRATEGY } from "../../types/looksrare";
 import { Domain, EIP712Protocol, VisualizationResult } from "../../types/visualizer";
-import { abiCoder, getPaymentAssetType } from "../../utils";
+import { WizardError, abiCoder, getPaymentAssetType } from "../../utils";
 import { strategiesLookup } from "./const";
 
 const { ERC1155, ERC721 } = ASSET_TYPE;
@@ -26,7 +26,7 @@ export const visualize = (
 
   const strategy = getExecutionStrategy(message.strategy);
   if (strategy === STRATEGY.UNKNOWN)
-    throw new Error(`unknown looksrare strategy ${message.strategy}`);
+    throw new WizardError(`unknown looksrare strategy ${message.strategy}`);
 
   const nftAsset: AssetInOut = {
     address: message.collection,


### PR DESCRIPTION
added WizardError instance to define custom errors

the custom error can be identified in a catch block by checking the error name:

```
error.name === "WizardError"
```

This will allow more flexible error handling by application, The custom error `WizardError` is meant for soft errors, for example unsupported chain, unexpected protocol strategy change..etc

The normal `Error` is meant for internal errors (assert statements)

For more details see: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Errors
