### PR TITLE
Feat/seaport v1.5

### DIFF
--- a/src/simulator/index.ts
+++ b/src/simulator/index.ts
@@ -90,7 +90,7 @@ export default class Simulator {
           type: NATIVE,
           from: call.from,
           to: call.to,
-          amount: call.value,
+          amount: BigInt(call.value).toString(),
           id: "",
         });
       }
@@ -103,6 +103,7 @@ export default class Simulator {
         // keccak256(Transfer(address,address,uint256))
         if (eventHash === ERC20_ERC721_TRANSFER_TOPIC) {
           // ERC20 Transfer event have a topics array of 3 elements (eventHash, and 2 indexed addresses)
+          // This one also covers cryptoPunks but as ERC20 token only, if we notice a high volume we can support `PunkBought` event
           if (event.topics.length === 3) {
             const [, _from, _to] = event.topics;
             const from = addressFrom32bytesTo20bytes(_from);
@@ -115,9 +116,11 @@ export default class Simulator {
               to,
               amount,
             });
-          }
-          // ERC721 Transfer event have a topics array of 4 elements (eventHash, and 2 indexed addresses and an indexed tokenId)
-          else {
+          } else {
+            /**
+             * @dev ERC721 Transfer event have a topics array of 4 elements (eventHash, and 2 indexed addresses and an indexed tokenId)
+             * the explicit `else` also cover CryptoKitties case where non of event arguments is indexed (event.topics.length ===1) @see https://etherscan.io/address/0x06012c8cf97bead5deae237070f9587f8e7a266d#code
+             */
             const [, _from, _to, _tokenId] = event.topics;
             const from = addressFrom32bytesTo20bytes(_from);
             const to = addressFrom32bytesTo20bytes(_to);

--- a/src/visualizer/seaport/index.ts
+++ b/src/visualizer/seaport/index.ts
@@ -177,8 +177,10 @@ const supportedChains = [
  * and there's a note regarding some limitation so we decided to not support them
  * @see https://github.com/ProjectOpenSea/seaport#deployments-by-evm-chain
  * @see https://github.com/ProjectOpenSea/seaport-js/blob/main/src/constants.ts#L5
+ * @see https://docs.opensea.io/changelog/seaport-1-5-release
  */
 const addressesBook = [
+  "0x00000000000000adc04c56bf30ac9d3c0aaf14dc", //v1.5 https://docs.opensea.io/changelog/seaport-1-5-release
   "0x00000000000001ad428e4906aE43D8F9852d0dD6", //v1.4
   "0x00000000006c3852cbEf3e08E8dF289169EdE581", //v1.1
 ].map((e) => e.toLocaleLowerCase());


### PR DESCRIPTION
Seaport v1.5 didn't introduce any business logic changes as per 0age [tweet](https://twitter.com/z0age/status/1651244503901290497) and Opensea release [post](https://docs.opensea.io/changelog/seaport-1-5-release)

This PR includes a minor fix for Native amount been a hex value, we convert it back to decimal value now using `BigInt` `toString` prototype to keep consistency  